### PR TITLE
chore: Update keyutils to 1.6.3-4

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+keyutils (1.6.3-4) unstable; urgency=medium
+
+  * Team upload.
+  * Drop patch from #1070012
+  * Disable page size check during test
+
+ -- Jochen Sprickerhof <jspricke@debian.org>  Thu, 24 Oct 2024 14:29:21 +0200
+
 keyutils (1.6.3-3.1) unstable; urgency=medium
 
   * Non-maintainer upload.

--- a/debian/copyright
+++ b/debian/copyright
@@ -14,7 +14,8 @@ License: LGPL-2+
 Files: debian/*
 Copyright: 2006-2013, Daniel Baumann <mail@daniel-baumann.ch>
            2013, Luk Claes <luk@debian.org>
-	   2014-2022, Christian Kastner <ckk@debian.org>
+	   2014-2024, Christian Kastner <ckk@debian.org>
+	   2024, Helmut Grohne <helmut@subdivi.de>
 License: LGPL-2+
 
 License: GPL-2+

--- a/debian/patches/Disable-page-size-check-during-test.patch
+++ b/debian/patches/Disable-page-size-check-during-test.patch
@@ -1,0 +1,50 @@
+From: Jochen Sprickerhof <jspricke@debian.org>
+Date: Thu, 24 Oct 2024 14:14:02 +0200
+Subject: Disable page size check during test
+
+This fixes the build on ppc64el
+---
+ tests/keyctl/add/bad-args/runtest.sh     | 2 +-
+ tests/keyctl/newring/bad-args/runtest.sh | 2 +-
+ tests/keyctl/padd/bad-args/runtest.sh    | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tests/keyctl/add/bad-args/runtest.sh b/tests/keyctl/add/bad-args/runtest.sh
+index 69121b2..cce2e1f 100644
+--- a/tests/keyctl/add/bad-args/runtest.sh
++++ b/tests/keyctl/add/bad-args/runtest.sh
+@@ -40,7 +40,7 @@ create_key --fail keyring wibble a @p
+ expect_error EINVAL
+ 
+ # check that an max length key description works correctly (PAGE_SIZE inc NUL)
+-if [ $PAGE_SIZE -lt $maxsquota ]
++if [ 1 ]
+ then
+     marker "CHECK MAXLEN DESC"
+     create_key --new=keyid user $maxdesc stuff @s
+diff --git a/tests/keyctl/newring/bad-args/runtest.sh b/tests/keyctl/newring/bad-args/runtest.sh
+index f35c4c6..0691d57 100644
+--- a/tests/keyctl/newring/bad-args/runtest.sh
++++ b/tests/keyctl/newring/bad-args/runtest.sh
+@@ -10,7 +10,7 @@ result=PASS
+ echo "++++ BEGINNING TEST" >$OUTPUTFILE
+ 
+ # check that an max length key description works correctly (4096 inc NUL)
+-if [ $PAGE_SIZE -lt $maxsquota ]
++if [ 1 ]
+ then
+     marker "CHECK MAXLEN DESC"
+     create_keyring --new=keyid $maxdesc @s
+diff --git a/tests/keyctl/padd/bad-args/runtest.sh b/tests/keyctl/padd/bad-args/runtest.sh
+index c59393c..84dbe31 100644
+--- a/tests/keyctl/padd/bad-args/runtest.sh
++++ b/tests/keyctl/padd/bad-args/runtest.sh
+@@ -40,7 +40,7 @@ pcreate_key --fail stuff keyring wibble @p
+ expect_error EINVAL
+ 
+ # check that an max length key description works correctly
+-if [ $PAGE_SIZE -lt $maxsquota ]
++if [ 1 ]
+ then
+     marker "CHECK MAXLEN DESC"
+     pcreate_key --new=keyid stuff user $maxdesc @s

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -6,4 +6,4 @@ pkg-config-install-tweaks.patch
 man-page-fixes.patch
 Tests-for-KEYCTL_MOVE-require-kernel-5.3-or-above.patch
 Mark-test-requiring-root-as-such.patch
-1070012-root.patch
+Disable-page-size-check-during-test.patch


### PR DESCRIPTION
Link: http://deb.debian.org/debian/pool/main/k/keyutils/keyutils_1.6.3.orig.tar.gz
Link: http://deb.debian.org/debian/pool/main/k/keyutils/keyutils_1.6.3-4.debian.tar.xz